### PR TITLE
chore: [SETI-648] Reduce Workflow Execution Time

### DIFF
--- a/.github/workflows/check-no-deploy-window.yml
+++ b/.github/workflows/check-no-deploy-window.yml
@@ -1,0 +1,40 @@
+name: Check No Deploy Window
+on:
+  # Runs every Mon-Friday at 4:00 and 10:00 UTC
+  schedule:
+    - cron:  '0 4,10 * * 1-5'
+  pull_request:
+    branches:
+      - master
+jobs:
+  should_deploy:
+    runs-on: ubuntu-latest
+    name: check no deploy window
+    steps:
+      - name: is deploy calendar busy?
+        uses: Typeform/siesta@v1.3
+        id: siesta
+        with:
+          google-credentials: ${{ secrets.siesta_google_credentials }}
+          google-token: ${{ secrets.siesta_google_token }}
+          google-calendar-id: ${{ secrets.siesta_google_calendar_id }}
+          custom-calendar-busy-message: 'There is an event in the Calendar. Deploying not recommended.'
+          custom-calendar-not-busy-message: 'No event in the Calendar. Feel free to deploy.'
+          fail-if-busy: false
+          minutes-interval: 360
+      - name: set label action based on result
+        uses: haya14busa/action-cond@v1.0.0
+        id: condval
+        with:
+          cond: ${{steps.siesta.outputs.calendar-busy}}
+          if_true: add
+          if_false: remove
+      - name: add or remove label
+        uses: Typeform/labeler@v1.2
+        id: labeler
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository-name: ${{ github.repository }}
+          label: no-deploy-window
+          label-action: ${{steps.condval.outputs.value}}
+          base-branch: master


### PR DESCRIPTION

 :warning: You are expected to review and merge. Don't wait for the bot to merge, because it won't.
 What is this? We are trying to reduce the time spent by the github action, so this action is executed twice a day on weekdays instead of every hour
 Why no-deploy-window? To know more about this: https://www.notion.so/typeform/Deployments-on-Friday-9fae5817e5934e5c9496331b6fa21c8c 
 :robot: I'm a  bot, if you have any doubts, contact #seti on slack.